### PR TITLE
[#3] Processing to BQ error, insertErrors

### DIFF
--- a/bigquery-setup/schema.json
+++ b/bigquery-setup/schema.json
@@ -329,6 +329,11 @@
         "mode": "NULLABLE"
       },
       {
+        "name": "translator_type",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
         "name": "profile_background_color",
         "type": "STRING",
         "mode": "NULLABLE"
@@ -755,6 +760,16 @@
         "mode": "NULLABLE"
       },
       {
+        "name": "reply_count",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "quote_count",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
         "name": "user",
         "type": "RECORD",
         "mode": "NULLABLE",
@@ -862,6 +877,11 @@
           {
             "name": "is_translator",
             "type": "BOOLEAN",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "translator_type",
+            "type": "STRING",
             "mode": "NULLABLE"
           },
           {


### PR DESCRIPTION
In Issue #3, the insert of some tweet data into BigQuery fails because the schema is missing these keys:
retweeted_status.reply_count
retweeted_status.user.translator_type
retweeted_status.quote_count
user.translator_type

This commit fixes the schema to include these new keys

Fixes #3